### PR TITLE
Added cURL proxy support

### DIFF
--- a/lib/class-sendgrid-tools.php
+++ b/lib/class-sendgrid-tools.php
@@ -18,6 +18,21 @@ class Sendgrid_Tools
     curl_setopt( $ch, CURLOPT_URL, $url );
     curl_setopt( $ch, CURLOPT_RETURNTRANSFER, TRUE );
 
+    // cURL proxy support
+    $proxy = new \WP_HTTP_Proxy();
+
+    if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
+
+      curl_setopt( $ch, CURLOPT_PROXYTYPE, CURLPROXY_HTTP );
+      curl_setopt( $ch, CURLOPT_PROXY, $proxy->host() );
+      curl_setopt( $ch, CURLOPT_PROXYPORT, $proxy->port() );
+
+      if ( $proxy->use_authentication() ) {
+        curl_setopt( $ch, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+        curl_setopt( $ch, CURLOPT_PROXYUSERPWD, $proxy->authentication() );
+      }
+    }
+
     $data = curl_exec( $ch );
     curl_close( $ch );
 
@@ -44,6 +59,21 @@ class Sendgrid_Tools
     $process = curl_init();
     curl_setopt( $process, CURLOPT_URL, "http://sendgrid.com/$api?$data" );
     curl_setopt( $process, CURLOPT_RETURNTRANSFER, 1 );
+
+    // cURL proxy support
+    $proxy = new \WP_HTTP_Proxy();
+
+    if ( $proxy->is_enabled() && $proxy->send_through_proxy( $url ) ) {
+
+      curl_setopt( $process, CURLOPT_PROXYTYPE, CURLPROXY_HTTP );
+      curl_setopt( $process, CURLOPT_PROXY, $proxy->host() );
+      curl_setopt( $process, CURLOPT_PROXYPORT, $proxy->port() );
+
+      if ( $proxy->use_authentication() ) {
+        curl_setopt( $process, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+        curl_setopt( $process, CURLOPT_PROXYUSERPWD, $proxy->authentication() );
+      }
+    }
 
     return curl_exec( $process );
   }

--- a/vendor/sendgrid-php/SendGrid/Web.php
+++ b/vendor/sendgrid-php/SendGrid/Web.php
@@ -138,6 +138,21 @@ class Web extends Api implements MailInterface
     curl_setopt($session, CURLOPT_CONNECTTIMEOUT, 5);
     curl_setopt($session, CURLOPT_TIMEOUT, 30);
 
+    // cURL proxy support
+    $proxy = new \WP_HTTP_Proxy();
+
+    if ( $proxy->is_enabled() && $proxy->send_through_proxy( $request ) ) {
+
+      curl_setopt( $session, CURLOPT_PROXYTYPE, CURLPROXY_HTTP );
+      curl_setopt( $session, CURLOPT_PROXY, $proxy->host() );
+      curl_setopt( $session, CURLOPT_PROXYPORT, $proxy->port() );
+
+      if ( $proxy->use_authentication() ) {
+        curl_setopt( $session, CURLOPT_PROXYAUTH, CURLAUTH_ANY );
+        curl_setopt( $session, CURLOPT_PROXYUSERPWD, $proxy->authentication() );
+      }
+    }
+
     // obtain response
     $response = curl_exec($session);
     curl_close($session);


### PR DESCRIPTION
I needed to add curl proxy support for SendGrid on my server. So I used the implementation of own wordpress for this. 
As I think others may need, I am submitting for review.

This requires that defines be made in the wp-config.php file to enable proxy support. 

```
define('WP_PROXY_HOST', '10.10.123.25');
define('WP_PROXY_PORT', '3128');
define('WP_PROXY_USERNAME', '');
define('WP_PROXY_PASSWORD', '');
define('WP_PROXY_BYPASS_HOSTS', 'localhost, www.example.com, *.wordpress.org');
```