### PR TITLE
Fix for fatal error on no response from SendGrid server

### DIFF
--- a/lib/class-sendgrid-tools.php
+++ b/lib/class-sendgrid-tools.php
@@ -15,6 +15,10 @@ class Sendgrid_Tools
     $url .= "api_user=$username&api_key=$password";
 
     $response = wp_remote_get( $url );
+    if ( !is_array($response) || !isset( $response['body'] ) )
+    {
+      return false;
+    }
     $response = json_decode( $response['body'], true );
 
     if ( isset( $response['error'] ) )
@@ -38,6 +42,10 @@ class Sendgrid_Tools
     $url = "https://sendgrid.com/$api?$data";
 
     $response = wp_remote_get( $url );
+    if ( !is_array($response) || !isset( $response['body'] ) )
+    {
+      return false;
+    }
 
     return $response['body'];
   }

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: team-rs
 Donate link: http://sendgrid.com/
 Tags: email, email reliability, email templates, sendgrid, smtp, transactional email, wp_mail,email infrastructure, email marketing, marketing email, deliverability, email deliverability, email delivery, email server, mail server, email integration, cloud email
 Requires at least: 3.3
-Tested up to: 4.0.1
+Tested up to: 4.1.1
 Stable tag: 1.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This fixes the problem with an empty response leading to the WordPress administration interface not loading, as discussed in [https://wordpress.org/support/topic/fatal-error-occurs-in-version-150] and [https://wordpress.org/support/topic/fatal-error-1544].