### PR TITLE
Fix broken include

### DIFF
--- a/vendor/sendgrid-php/sendgrid-php.php
+++ b/vendor/sendgrid-php/sendgrid-php.php
@@ -1,4 +1,4 @@
 <?php
-require 'vendor/autoload.php';
-require 'lib/SendGrid.php';
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/lib/SendGrid.php';
 ?>


### PR DESCRIPTION
`vendor/autoload.php` is specified relatively, and PHP says the file doesn't exist, so mail isn't being sent. Using `__DIR__` makes the include a full system path and fixes the issue.

Note that this issue will only occur on sites with a `vendor` directory in the root. PHP is seeing that and guessing (wrongly) that’s the one you mean. By being explicit, it won't guess wrongly.