### PR TITLE
Category Stats v3 Endpoint Changes

### DIFF
--- a/lib/class-sendgrid-statistics.php
+++ b/lib/class-sendgrid-statistics.php
@@ -129,9 +129,9 @@ class Sendgrid_Statistics
 
     if ( $_POST['type'] && 'general' != $_POST['type'] ) {
       if( 'wordpress' == $_POST['type'] ) {
-        $parameters['category'] = 'wp_sendgrid_plugin';
+        $parameters['categories'] = 'wp_sendgrid_plugin';
       } else {
-        $parameters['category'] = urlencode( $_POST['type'] );
+        $parameters['categories'] = urlencode( $_POST['type'] );
       }
     }
 

--- a/lib/class-sendgrid-statistics.php
+++ b/lib/class-sendgrid-statistics.php
@@ -127,15 +127,18 @@ class Sendgrid_Statistics
       $parameters['end_date']   = $_POST['end_date'];
     }
 
+    $endpoint = 'v3/stats';
+    
     if ( $_POST['type'] && 'general' != $_POST['type'] ) {
       if( 'wordpress' == $_POST['type'] ) {
         $parameters['categories'] = 'wp_sendgrid_plugin';
       } else {
         $parameters['categories'] = urlencode( $_POST['type'] );
       }
+      $endpoint = 'v3/categories/stats';
     }
 
-    echo Sendgrid_Tools::curl_request( 'v3/stats', $parameters );
+    echo Sendgrid_Tools::curl_request( $endpoint, $parameters );
 
     die();
   }


### PR DESCRIPTION
I noticed that if the user chose to view category stats, general global stats were being returned. The v3 endpoint for category stats is 'v3/categories/stats' and the correct parameter name is 'categories', not 'category'.

https://sendgrid.com/docs/API_Reference/Web_API_v3/Stats/categories.html

This is literally my first ever contribution to an open-source project through GitHub. Please let me know if I did something wrong.