### PR TITLE
Hides fatal error caused by failed wp_remote_post.

### DIFF
--- a/lib/sendgrid/class-sendgrid-api.php
+++ b/lib/sendgrid/class-sendgrid-api.php
@@ -48,6 +48,8 @@ class Sendgrid_API implements Sendgrid_Send {
     }
 
     $response = wp_remote_post( self::URL, $data );
+    if ( !is_array($response) || !isset( $response['body'] ) )
+      return false;
 
     if ( "success" == json_decode( $response['body'])->message )
       return true;


### PR DESCRIPTION
Based on previous PR #19.

Closes #30.