### PR TITLE
API permission check before adding Statistics menu item

### DIFF
--- a/lib/class-sendgrid-statistics.php
+++ b/lib/class-sendgrid-statistics.php
@@ -66,7 +66,7 @@ class Sendgrid_Statistics
     {
       case "apikey":
         $apikey = Sendgrid_Tools::get_api_key();
-        if ( ! Sendgrid_Tools::check_api_key( $apikey ) )
+        if ( ! Sendgrid_Tools::check_api_key_stats( $apikey ) )
           return;
       break;
 


### PR DESCRIPTION
Could we possible relocate [this error message](https://github.com/sendgrid/wordpress/blob/68efcaa3623987c786e5d1c240ea93c7e1c7ee52/lib/class-sendgrid-statistics.php#L93-L94) to somewhere else in the admin? We have a use case where we'd like to prevent access to the Statistics page. 

For new users, I can understand the value in showing that the page is available, but it's a bit odd in our scenario. If changing the permission check isn't an option, could we possibly have a constant or filter to stop the menu from being added? I suppose `remove_menu_page()` is always an option on our end, too...
