### PR TITLE
Set headers on Sendgrid\Email object

### DIFF
--- a/lib/sendgrid/sendgrid-wp-mail.php
+++ b/lib/sendgrid/sendgrid-wp-mail.php
@@ -398,6 +398,9 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
     $mail->setAsmGroupId( $unsubscribe_group_id );
   }
 
+  // set the headers
+  $mail->headers = $headers;
+
   $sendgrid = Sendgrid_WP::get_instance();
 
   if ( ! $sendgrid ) {


### PR DESCRIPTION
The headers provided to wp_mail are parsed for certain names, while others are set in a 'grand header' array and then forgotten.  

It allows wp_mail and other plugins to modify the headers directly which is handy if you want to set x-smtpapi yourself for e.g. open and click tracking.

AFAICT, this patch does not interfere with any other function currently implemented in the wordpress plugin.