### PR TITLE
Add support for smtpapi filters

### DIFF
--- a/lib/sendgrid/sendgrid-wp-mail.php
+++ b/lib/sendgrid/sendgrid-wp-mail.php
@@ -196,6 +196,16 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
                 $mail->addSmtpapiTo( $xsmtpapi_to );
               }
               break;
+            /* x-smtpapi-filters: filter_name:param_name=param_value,filter_name:param_name=param_value */
+            case 'x-smtpapi-filters':
+              $xsmtpapi_filters = explode( ',', trim($content) );
+              foreach ( $xsmtpapi_filters as $filter ) {
+                    list( $filter_name, $params ) = explode( ':', $filter );
+                    list( $param_name, $param_value ) = explode( '=', $params );
+
+                    $mail->smtpapi->addFilter($filter_name, $param_name, $param_value);
+              }
+              break;
             case 'substitutions':
               if ( false !== strpos( $content, ';' ) ) {
                 $substitutions = explode( ';', $content );


### PR DESCRIPTION
Like x-smtpapi-to, this adds support for setting x-smtpapi-filters via $headers as a comma-delimited string:

`filter_name:param_name=param_value,filter_name:param_name=param_value`

Which allows the plugin to set e.g: open and click tracking filters like so:
`x-smtpapi-filters: opentrack:enable=1,clicktrack:enable=1`

Hopefully it is OK to use the addFilter method of $mail->smtpapi directly.  Also, the only other comment is that this is missing basic validation on the inputs - that $filter has only 1 ':' and that $params has only 1 '='.

Otherwise, I think this is good now and it seems to work for me. :)
