### PR TITLE
Make NLVX::get_auth_header_value() protected instead of private

### DIFF
--- a/lib/class-sendgrid-nlvx.php
+++ b/lib/class-sendgrid-nlvx.php
@@ -11,7 +11,7 @@ class Sendgrid_NLVX
    *
    * @return  mixed   string of the header value if successful, false otherwise.
    */
-  private static function get_auth_header_value()
+  protected static function get_auth_header_value()
   {
     if ( "false" == Sendgrid_Tools::get_mc_opt_use_transactional() ) {
       $mc_api_key = Sendgrid_Tools::get_mc_api_key();


### PR DESCRIPTION
Making `Sendgrid_NLVX::get_auth_header_value()` protected instead of private improves extendability.

I for example implemented a `delete_recipient_from_list()` method, because we want subscribers to be able to unsubscribe on our website.