### PR TITLE
Fixed Tag Error

### DIFF
--- a/view/sendgrid_contextual_help.php
+++ b/view/sendgrid_contextual_help.php
@@ -1,3 +1,4 @@
+<?php ?>
 <p>
   Email Delivery. Simplified.
 </p>


### PR DESCRIPTION
PHP7 requires at least one opening tag and an optional closing tag.  This file only contains HTML and no PHP so we have to add a `<?php ?>` to appease the PHP runtime.  Otherwise the plugin fails PHP7 Compatibility Check.