### PR TITLE
Fix WordPress capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * Add ability to have and individual email sent to each recipient by setting x-smtpapi-to in headers
 
 **1.7.5**
-* Fixed an issue with the reset password email from Wordpress
+* Fixed an issue with the reset password email from WordPress
 * Updated validation for email addresses
 * Fixed an issue where some errors were not displayed on the settings page
 * Add substitutions functionality
@@ -449,7 +449,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * BREAKING CHANGE: Don't make update if you don't have mcrypt php library enabled
 * Added the possibility of setting the api key or username/password empty
 * Added the possibility of selecting the authentication method
-* Removed dependency on cURL, now all API requests are made through Wordpress
+* Removed dependency on cURL, now all API requests are made through WordPress
 * Sending mail via SMTP now supports API keys
 * Security improvements
 * Refactored old code
@@ -670,7 +670,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * Add ability to have and individual email sent to each recipient by setting x-smtpapi-to in headers
 
 **1.7.5**
-* Fixed an issue with the reset password email from Wordpress
+* Fixed an issue with the reset password email from WordPress
 * Updated validation for email addresses
 * Fixed an issue where some errors were not displayed on the settings page
 * Add substitutions functionality
@@ -697,7 +697,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * BREAKING CHANGE: Don't make update if you don't have mcrypt php library enabled
 * Added the possibility of setting the api key or username/password empty
 * Added the possibility of selecting the authentication method
-* Removed dependency on cURL, now all API requests are made through Wordpress
+* Removed dependency on cURL, now all API requests are made through WordPress
 * Sending mail via SMTP now supports API keys
 * Security improvements
 * Refactored old code

--- a/lib/class-sendgrid-statistics.php
+++ b/lib/class-sendgrid-statistics.php
@@ -57,7 +57,7 @@ class Sendgrid_Statistics
       return;
     }
 
-    add_meta_box( 'sendgrid_statistics_widget', 'SendGrid Wordpress Statistics', array( __CLASS__, 'show_dashboard_widget' ),
+    add_meta_box( 'sendgrid_statistics_widget', 'SendGrid WordPress Statistics', array( __CLASS__, 'show_dashboard_widget' ),
       'dashboard', 'normal', 'high' );
   }
 

--- a/readme.txt
+++ b/readme.txt
@@ -393,7 +393,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * Updated validation for email addresses in the headers field of the send test email form
 * Add ability to have and individual email sent to each recipient by setting x-smtpapi-to in headers
 = 1.7.5 =
-* Fixed an issue with the reset password email from Wordpress
+* Fixed an issue with the reset password email from WordPress
 * Updated validation for email addresses
 * Fixed an issue where some errors were not displayed on the settings page
 * Add substitutions functionality
@@ -415,7 +415,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * BREAKING CHANGE: Don't make update if you don't have mcrypt php library enabled
 * Added the possibility of setting the api key or username/password empty
 * Added the possibility of selecting the authentication method
-* Removed dependency on cURL, now all API requests are made through Wordpress
+* Removed dependency on cURL, now all API requests are made through WordPress
 * Sending mail via SMTP now supports API keys
 * Security improvements
 * Refactored old code
@@ -576,7 +576,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * Updated validation for email addresses in the headers field of the send test email form
 * Add ability to have and individual email sent to each recipient by setting x-smtpapi-to in headers
 = 1.7.5 =
-* Fixed an issue with the reset password email from Wordpress
+* Fixed an issue with the reset password email from WordPress
 * Updated validation for email addresses
 * Fixed an issue where some errors were not displayed on the settings page
 * Add substitutions functionality
@@ -598,7 +598,7 @@ The value is in seconds, this means that API requests will wait 10 seconds for a
 * BREAKING CHANGE: Don't make update if you don't have mcrypt php library enabled
 * Added the possibility of setting the api key or username/password empty
 * Added the possibility of selecting the authentication method
-* Removed dependency on cURL, now all API requests are made through Wordpress
+* Removed dependency on cURL, now all API requests are made through WordPress
 * Sending mail via SMTP now supports API keys
 * Security improvements
 * Refactored old code

--- a/view/sendgrid_stats.php
+++ b/view/sendgrid_stats.php
@@ -5,7 +5,7 @@
         <img src="<?php echo plugins_url( '/images/logo.png', __FILE__ ) ?>" width="100" alt="" />
       </a>
     </div>
-    <h2 id="sendgrid-wordpress-statistics-header" class="sendgrid-statistics-header-toggle">SendGrid Wordpress Statistics</h2>
+    <h2 id="sendgrid-wordpress-statistics-header" class="sendgrid-statistics-header-toggle">SendGrid WordPress Statistics</h2>
     <h2 id="sendgrid-general-statistics-header" class="sendgrid-statistics-header-toggle" style="display: none;">SendGrid General Statistics</h2>
     <h2 id="sendgrid-category-statistics-header" class="sendgrid-statistics-header-toggle" style="display: none;">SendGrid Categories Statistics</h2>
     <?php if ( isset( $status ) and ( 'error' == $status ) ): ?>
@@ -20,7 +20,7 @@
   <div class="pull-right sendgrid-statistics-change-type">
     <select id="sendgrid-statistics-change-type">
       <option value="general">General statistics</option>
-      <option value="wordpress" selected="selected">Wordpress statistics</option>
+      <option value="wordpress" selected="selected">WordPress statistics</option>
       <?php $categories = Sendgrid_Tools::get_categories_array(); ?>
       <?php if ( is_array( $categories ) and count( $categories ) > 0 ): ?>
       <optgroup label="Categories:">


### PR DESCRIPTION
Howdy folks. Great plugin!

I've noticed the incorrect capitalization of WordPress throughout the SendGrid plugin. Since the WP community is touchy about the spelling of WordPress, this commit fixes all incorrect occurrences or _Wordpress_ with _WordPress_.

I hope that helps!