### PR TITLE
Implement smtp logging into /var/log/sendgrid.log and retry on failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "sendgrid/sendgrid-email-delivery-simplified",
+  "description": "",
+  "type": "wordpress-plugin",
+  "license": "proprietary",
+  "authors": [
+    {
+      "name": "Leigh Bicknell",
+      "email": "leigh@orangeleaf.com"
+    }
+  ],
+  "require": {
+    "composer/installers": "^1.4"
+  }
+}


### PR DESCRIPTION
As per my comment in issue #71 
Note that `/var/log/sendgrid.log` will need to be created and made http server writable by the user.

The solution isn't perfect, as 3 consecutive failures will still result in emails disappearing into the ether. However it should minimize this and at least provide logs of failures for users. And so work as a useful stop gap until a proper mail queuing system can be implemented.