### PR TITLE
reply-to case fix in valid_emails_in_headers

### DIFF
--- a/lib/class-sendgrid-tools.php
+++ b/lib/class-sendgrid-tools.php
@@ -1263,7 +1263,15 @@ class Sendgrid_Tools
 
             break;
           case 'reply-to':
-            if( ! Sendgrid_Tools::is_valid_email( $content ) ) {
+            if ( false !== strpos( $content, '<' ) ) {
+              $from_email = substr( $content, strpos( $content, '<' ) + 1 );
+              $from_email = str_replace( '>', '', $from_email );
+              $from_email = trim( $from_email );
+            } else {
+              $from_email = trim( $content );
+            }
+
+            if( ! Sendgrid_Tools::is_valid_email( $from_email ) ) {
               return false;
             }
 


### PR DESCRIPTION
Currently valid_emails_in_headers fails for Reply-To headers that are name + email, even though they are correct and are accepted by sendgrid.